### PR TITLE
Add margin between nav links

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -27,6 +27,11 @@ header[role=banner] h1 {
   padding-top: 0;
 }
 
+nav[role=navigation] a {
+  display: inline-block;
+  margin: 0 0.5rem 0 0;
+}
+
 footer[role=contentinfo] {
   border-top: 1px solid black;
   margin-bottom: 3rem;


### PR DESCRIPTION
These styles were inspired by [the navigation styles](https://github.com/kemitchell/doormatprivacy.com/blob/2c4fcf88e89a7aef37a0ace6623c9fcacb47a346/styles.css#L26-L29) on https://doormatprivacy.com/. Since the navigation is not center-aligned here, I thought the navigation looked more cohesive with only 0.5rem between links rather than 1rem.

I tested this only with the style editor in my browser’s developer tools.

### Before

> ![before adding spacing between nav links](https://user-images.githubusercontent.com/79168/101979487-76d71700-3c2b-11eb-89d4-70121d3bcda5.png)

### After

> ![after adding spacing between nav links](https://user-images.githubusercontent.com/79168/101979492-7dfe2500-3c2b-11eb-922a-951a1bc7cba1.png)
